### PR TITLE
NGワード追加

### DIFF
--- a/ngwords.txt
+++ b/ngwords.txt
@@ -16,6 +16,7 @@ chinko
 chinpo
 tinko
 tinpo
+陰茎
 -ビックリマンコラボ
 -ウルトラマンコスモス
 まんこ


### PR DESCRIPTION
陰茎をNGワードとして追加します。

理由としてですが、まんこ、陰唇は入っているのにちんこは入っていて陰茎がNG指定されていないのは漏れかなと思ったので、男性器を指す単語として追加しました。